### PR TITLE
III-3128 Add method to set a list of cardsystems on an event

### DIFF
--- a/CultureFeed/CultureFeed/Uitpas.php
+++ b/CultureFeed/CultureFeed/Uitpas.php
@@ -474,6 +474,16 @@ interface CultureFeed_Uitpas {
   public function eventHasTicketSales($cdbid);
 
   /**
+   * Sets card systems to the event.
+   *
+   * @param string $cdbid
+   * @param array $cardSystemIds
+   *
+   * @return CultureFeed_Uitpas_Response
+   */
+  public function setCardSystemsForEvent($cdbid, array $cardSystemIds);
+
+  /**
    * Add a card system to the event.
    *
    * @param string $cdbid

--- a/CultureFeed/CultureFeed/Uitpas/Default.php
+++ b/CultureFeed/CultureFeed/Uitpas/Default.php
@@ -394,6 +394,16 @@ class CultureFeed_Uitpas_Default implements CultureFeed_Uitpas {
     }
   }
 
+  public function setCardSystemsForEvent($cdbid, array $cardSystemIds)
+  {
+    return $this->consumerPostWithSimpleResponse(
+      'uitpas/cultureevent/' . $cdbid . '/preset_cardsystems',
+      [
+        'cardSystemId' => $cardSystemIds,
+      ]
+    );
+  }
+
   /**
    * {@inheritdoc}
    */


### PR DESCRIPTION
### Added

- Added a method to set a definitive list of card systems on an event

---

Ticket: https://jira.uitdatabank.be/browse/III-3128