### PR TITLE
UPS-3236 Add method to fetch financial overview report periods

### DIFF
--- a/CultureFeed/CultureFeed/Uitpas.php
+++ b/CultureFeed/CultureFeed/Uitpas.php
@@ -543,6 +543,12 @@ interface CultureFeed_Uitpas {
   );
 
   /**
+   * @param string $consumer_key_counter
+   * @return CultureFeed_Uitpas_Calendar_Period[]
+   */
+  public function getFinancialOverviewReportPeriods($consumer_key_counter);
+
+  /**
    * @param string $uid
    * @param string $assocationId
    * @param string|null $consumer_key_counter

--- a/CultureFeed/CultureFeed/Uitpas/Calendar/Period.php
+++ b/CultureFeed/CultureFeed/Uitpas/Calendar/Period.php
@@ -17,4 +17,17 @@ class CultureFeed_Uitpas_Calendar_Period {
    */
   public $dateto;
 
+  /**
+   * @param CultureFeed_SimpleXMLElement $object
+   * @return CultureFeed_Uitpas_Calendar_Period
+   */
+  public static function createFromXml(CultureFeed_SimpleXMLElement $object)
+  {
+    $period = new self();
+
+    $period->datefrom = $object->xpath_time('startDate');
+    $period->dateto = $object->xpath_time('endDate');
+
+    return $period;
+  }
 }

--- a/CultureFeed/CultureFeed/Uitpas/Calendar/Period.php
+++ b/CultureFeed/CultureFeed/Uitpas/Calendar/Period.php
@@ -17,6 +17,12 @@ class CultureFeed_Uitpas_Calendar_Period {
    */
   public $dateto;
 
+  public function __construct($datefrom = null, $dateto = null)
+  {
+    $this->datefrom = $datefrom;
+    $this->dateto = $dateto;
+  }
+
   /**
    * @param CultureFeed_SimpleXMLElement $object
    * @return CultureFeed_Uitpas_Calendar_Period

--- a/CultureFeed/CultureFeed/Uitpas/Default.php
+++ b/CultureFeed/CultureFeed/Uitpas/Default.php
@@ -1716,6 +1716,38 @@ class CultureFeed_Uitpas_Default implements CultureFeed_Uitpas {
     return $response;
   }
 
+  /**
+   * @param string $consumer_key_counter
+   * @return CultureFeed_Uitpas_Calendar_Period[]
+   * @throws CultureFeed_ParseException
+   */
+  public function getFinancialOverviewReportPeriods($consumer_key_counter)
+  {
+    $params = array(
+      'balieConsumerKey' => $consumer_key_counter,
+    );
+
+    $response = $this->oauth_client->authenticatedGetAsXml(
+      'uitpas/report/financialoverview/organiser/periods',
+      $params
+    );
+
+    try {
+      $xml = new CultureFeed_SimpleXMLElement($response);
+    }
+    catch (Exception $e) {
+      throw new CultureFeed_ParseException($response);
+    }
+
+    $periods = array();
+
+    foreach ($xml->periods->period as $periodXml) {
+      $periods[] = CultureFeed_Uitpas_Calendar_Period::createFromXML($periodXml);
+    }
+
+    return $periods;
+  }
+
   public function deleteMembership($uid, $assocationId, $consumer_key_counter = NULL) {
     $data = array(
       'uid' => $uid,

--- a/CultureFeed/test/uitpas/CultureFeed_Uitpas_FinancialOverviewExportAPITest.php
+++ b/CultureFeed/test/uitpas/CultureFeed_Uitpas_FinancialOverviewExportAPITest.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * @file
- */
 
 class CultureFeed_Uitpas_FinancialOverviewExportAPITest extends PHPUnit_Framework_TestCase {
 

--- a/CultureFeed/test/uitpas/CultureFeed_Uitpas_FinancialOverviewExportAPITest.php
+++ b/CultureFeed/test/uitpas/CultureFeed_Uitpas_FinancialOverviewExportAPITest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @file
+ */
+
+class CultureFeed_Uitpas_FinancialOverviewExportAPITest extends PHPUnit_Framework_TestCase {
+
+  public function testGetFinancialOverviewReportPeriods() {
+    $oauth_client_stub = $this->createMock('CultureFeed_OAuthClient');
+
+    $balie_consumer_key = 'e52efb7f-2eab-47a5-9cf3-9e7413ffd942';
+
+    $xml = file_get_contents(__DIR__ . '/data/financial_overview_reports/periods.xml');
+
+    $oauth_client_stub
+      ->method('authenticatedGetAsXml')
+      ->with('uitpas/report/financialoverview/organiser/periods', array(
+          'balieConsumerKey' => $balie_consumer_key,
+        ))
+      ->willReturn($xml);
+
+    $cf = new CultureFeed($oauth_client_stub);
+
+    $result = $cf->uitpas()->getFinancialOverviewReportPeriods($balie_consumer_key);
+
+    $this->assertEquals(
+      [
+        new CultureFeed_Uitpas_Calendar_Period(
+          1585692000,
+          1593554399
+        ),
+        new CultureFeed_Uitpas_Calendar_Period(
+          1577833200,
+          1585691999
+        ),
+        new CultureFeed_Uitpas_Calendar_Period(
+          1569880800,
+          1577833199
+        ),
+      ],
+      $result
+    );
+  }
+}

--- a/CultureFeed/test/uitpas/data/financial_overview_reports/periods.xml
+++ b/CultureFeed/test/uitpas/data/financial_overview_reports/periods.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+    <code>ACTION_SUCCEEDED</code>
+    <periods>
+        <period>
+            <endDate>2020-06-30T23:59:59.999+02:00</endDate>
+            <startDate>2020-04-01T00:00:00+02:00</startDate>
+        </period>
+        <period>
+            <endDate>2020-03-31T23:59:59.999+02:00</endDate>
+            <startDate>2020-01-01T00:00:00+01:00</startDate>
+        </period>
+        <period>
+            <endDate>2019-12-31T23:59:59.999+01:00</endDate>
+            <startDate>2019-10-01T00:00:00+02:00</startDate>
+        </period>
+    </periods>
+</response>


### PR DESCRIPTION
### Added

- Method to fetch financial overview report periods

---

Ticket: https://jira.uitdatabank.be/browse/UPS-3236

Note: The code style in this library is not great, and we still need to support PHP 5.6 because it's used in a lot of legacy projects. I tried to at least stay consistent with the rest of the code and focused on backwards compatibility, not refactoring/cleanup.

It's still a draft for now because I need to double check that it actually works when used in https://github.com/cultuurnet/uitpas-beheer-silex 