### PR TITLE
PHP 7.4 compatibility: don't use curly braces for arrays

### DIFF
--- a/OAuth/OAuth.php
+++ b/OAuth/OAuth.php
@@ -115,7 +115,7 @@ if (!class_exists('OAuthSignatureMethod')) {
       // Avoid a timing leak with a (hopefully) time insensitive compare
       $result = 0;
       for ($i = 0; $i < strlen($signature); $i++) {
-        $result |= ord($built{$i}) ^ ord($signature{$i});
+        $result |= ord($built[$i]) ^ ord($signature[$i]);
       }
 
       return $result == 0;


### PR DESCRIPTION
This fixes the package on PHP 7.4, where I ran across this deprecation error. https://wiki.php.net/rfc/deprecate_curly_braces_array_access