### PR TITLE
UPS-3665 Add method to add "counter" member by email

### DIFF
--- a/CultureFeed/CultureFeed/Uitpas.php
+++ b/CultureFeed/CultureFeed/Uitpas.php
@@ -389,6 +389,14 @@ interface CultureFeed_Uitpas {
    */
   public function addMemberToCounter($uid, $consumer_key_counter = NULL);
 
+  /**
+   * Add a member to a counter using their email address.
+   *
+   * @param string $email The UiTID user email (v1 or v2)
+   * @param string $consumer_key_counter The consumer key of the counter from where the request originates
+   */
+  public function addMemberToCounterUsingEmail($email, $consumer_key_counter = NULL);
+
   public function removeMemberFromCounter($uid, $consumer_key_counter = NULL);
 
   public function getMembersForCounter($consumer_key_counter = NULL);

--- a/CultureFeed/CultureFeed/Uitpas.php
+++ b/CultureFeed/CultureFeed/Uitpas.php
@@ -395,7 +395,7 @@ interface CultureFeed_Uitpas {
    * @param string $email The UiTID user email (v1 or v2)
    * @param string $consumer_key_counter The consumer key of the counter from where the request originates
    */
-  public function addMemberToCounterUsingEmail($email, $consumer_key_counter = NULL);
+  public function addMemberToCounterByEmail($email, $consumer_key_counter = NULL);
 
   public function removeMemberFromCounter($uid, $consumer_key_counter = NULL);
 

--- a/CultureFeed/CultureFeed/Uitpas/Default.php
+++ b/CultureFeed/CultureFeed/Uitpas/Default.php
@@ -1381,6 +1381,24 @@ class CultureFeed_Uitpas_Default implements CultureFeed_Uitpas {
     $this->oauth_client->authenticatedPost('uitpas/balie/member', $data);
   }
 
+  /**
+   * Add a member to a counter using their email address.
+   *
+   * @param string $email The UiTID user email (v1 or v2)
+   * @param string $consumer_key_counter The consumer key of the counter from where the request originates
+   */
+  public function addMemberToCounterUsingEmail($email, $consumer_key_counter = NULL) {
+    $data = array(
+      'email' => $email,
+    );
+
+    if ($consumer_key_counter) {
+      $data['balieConsumerKey'] = $consumer_key_counter;
+    }
+
+    $this->oauth_client->authenticatedPost('uitpas/balie/member', $data);
+  }
+
   public function removeMemberFromCounter($uid, $consumer_key_counter = NULL) {
     $data = array(
       'uid' => $uid,

--- a/CultureFeed/CultureFeed/Uitpas/Default.php
+++ b/CultureFeed/CultureFeed/Uitpas/Default.php
@@ -1387,7 +1387,7 @@ class CultureFeed_Uitpas_Default implements CultureFeed_Uitpas {
    * @param string $email The UiTID user email (v1 or v2)
    * @param string $consumer_key_counter The consumer key of the counter from where the request originates
    */
-  public function addMemberToCounterUsingEmail($email, $consumer_key_counter = NULL) {
+  public function addMemberToCounterByEmail($email, $consumer_key_counter = NULL) {
     $data = array(
       'email' => $email,
     );

--- a/CultureFeed/CultureFeed/Uitpas/Default.php
+++ b/CultureFeed/CultureFeed/Uitpas/Default.php
@@ -6,7 +6,7 @@
 class CultureFeed_Uitpas_Default implements CultureFeed_Uitpas {
 
   use Culturefeed_ValidationTrait;
-  
+
   /**
    *
    * CultureFeed object to make CultureFeed core requests.


### PR DESCRIPTION
### Added

- Added method to add a counter member by email

---

Note: I just copied the existing `addMemberToCounter` and changed it to work with the new `email` parameter. I don't think there's a lot of value in trying to clean this up since this library is mostly used in code that is EOL.